### PR TITLE
Add .mailmap to show only BaikelWang as contributor

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+# Consolidate all commit identities to BaikelWang for GitHub Contributors display.
+# Format: <canonical name> <canonical email> <legacy name> <legacy email>
+# https://git-scm.com/docs/gitmailmap
+
+BaikelWang <2393947100@qq.com> Cursor Agent <cursoragent@cursor.com>
+BaikelWang <2393947100@qq.com> cursor[bot] <206951365+cursor[bot]@users.noreply.github.com>
+BaikelWang <2393947100@qq.com> Dieuwyx <2393947100@qq.com>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `.mailmap` to consolidate Cursor Agent, cursor[bot], and Dieuwyx commit identities under BaikelWang for GitHub Contributors display.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e1d87c7-82ae-4a29-a923-d63f0da0cb53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e1d87c7-82ae-4a29-a923-d63f0da0cb53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

