### PR TITLE
修复三篇旧文章中文日期格式导致每次部署重复生成

### DIFF
--- a/source/_posts/关于磁矩特征的写入.md
+++ b/source/_posts/关于磁矩特征的写入.md
@@ -1,7 +1,7 @@
 ---
 title: 关于磁矩特征的写入
 tags: [MP, CSAT, 科研, 凝聚态物理]
-date: 2025年7月4日 17:44:10
+date: 2025-07-04 17:44:10
 categories: 凝聚态物理与人工智能
 index_img : /img/关于磁矩特征写入/0.png
 ---

--- a/source/_posts/生日快乐.md
+++ b/source/_posts/生日快乐.md
@@ -1,7 +1,7 @@
 ---
 title: 生日快乐！
 tags: []
-date: 2025年7月17日 21:51:30
+date: 2025-07-17 21:51:30
 categories: 杂谈
 index_img : /img/生日快乐/2.png
 ---

--- a/source/_posts/训练带有磁矩的数据.md
+++ b/source/_posts/训练带有磁矩的数据.md
@@ -2,7 +2,7 @@
 ---
 title: 训练带有磁矩的数据
 tags: [MP, CSAT, 科研, 凝聚态物理]
-date: 2025年7月6日 16:59:11
+date: 2025-07-06 16:59:11
 categories: 凝聚态物理与人工智能
 index_img : /img/关于磁矩特征写入/0.png
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

三篇旧文章的 front matter 使用了中文日期格式（如 `2025年7月17日`），Hexo 无法解析，每次 CI 构建时回退到文件修改时间，导致 URL 路径变成当天日期并反复出现在部署提交中。

## 修复

将日期改为标准格式 `YYYY-MM-DD HH:mm:ss`：

- `关于磁矩特征的写入` → `2025-07-04`
- `训练带有磁矩的数据` → `2025-07-06`
- `生日快乐` → `2025-07-17`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e1d87c7-82ae-4a29-a923-d63f0da0cb53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e1d87c7-82ae-4a29-a923-d63f0da0cb53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

